### PR TITLE
Tuned performance for Dynamic quan kernel

### DIFF
--- a/benchmark/benchmark_dynamic_quant.py
+++ b/benchmark/benchmark_dynamic_quant.py
@@ -31,6 +31,7 @@ def benchmark(M, K, provider, input_dtype=torch.half, device="cuda"):
 
     if provider == "triton":
         flashnn.set_use_triton(True)
+        flashnn.set_autotune_triton_kernels(True)
         triton_dynamic_quant = flashnn.DynamicQuantize()
         ms, min_ms, max_ms = triton.testing.do_bench(
             lambda: triton_dynamic_quant(x), rep=100, quantiles=quantiles


### PR DESCRIPTION
If the auto tune enable function flashnn.set_use_triton(True) does not work, please change the line"if get_autotune_triton_kernels():" in dynamic_quant.py to hard code "if True" to reproduce the performance data after tunning